### PR TITLE
fix(ci): change Docker Hub README update trigger condition

### DIFF
--- a/.github/workflows/github-pipeline.yml
+++ b/.github/workflows/github-pipeline.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Update Docker Hub README
         uses: peter-evans/dockerhub-description@v4
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Use the "tag" trigger instead of a "published release" trigger