### PR TITLE
chore(renovate): change groupName to description

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "groupName": "Dependency minimum release age",
+      "description": "Dependency minimum release age must be 3 days",
       "matchManagers": [
         "gomod",
         "github-actions",


### PR DESCRIPTION
* The description for dependency minimum release age must not be printed into the PR title